### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+- "stable"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "mdast": "^1.2.0",
-    "mdast-lint": "^1.1.1"
+    "mdast-lint": "^1.1.1",
+    "mocha": "^2.3.4"
   }
 }

--- a/test/createMessage.js
+++ b/test/createMessage.js
@@ -2,6 +2,7 @@ module.exports = function createMessage(line, column) {
   return {
     name: line + ':' + column,
     file: '',
+    message: "Newline should follow end of sentence",
     reason: "Newline should follow end of sentence",
     line: line,
     column: column,


### PR DESCRIPTION
The first commit fixes the current tests. The warnings returned by the linter include a `message` attribute but the fixture doesn't contain that. With this change the tests pass locally for me (without 3 of 5 failed).

The second commit adds a travis file to run the tests automatically. The travis integration needs to be enabled by an admin to be effective.
