### PR TITLE
rename mdast dependencies to remark

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "url": "git+https://github.com/chcokr/mdast-lint-sentence-newline.git"
   },
   "keywords": [
-    "mdast",
-    "mdast-lint",
-    "mdast-plugin",
+    "remark",
+    "remark-lint",
+    "remark-plugin",
     "markdown",
     "lint"
   ],
@@ -27,7 +27,7 @@
     "unist-util-visit": "^1.0.0"
   },
   "devDependencies": {
-    "mdast": "^1.2.0",
-    "mdast-lint": "^1.1.1"
+    "remark": "^3.1.0",
+    "remark-lint": "^2.0.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var fs = require('fs');
-var mdast = require('mdast');
-var lintPlugin = require('mdast-lint');
+var remark = require('remark');
+var lintPlugin = require('remark-lint');
 var path = require('path');
 
 var directories = fs.readdirSync(__dirname).filter(function(file) {
@@ -14,7 +14,7 @@ describe('The rule passes', function () {
 
     it(dir, function (done) {
 
-      var processor = mdast().use(lintPlugin, {
+      var processor = remark().use(lintPlugin, {
         external: ['../index.js']
       });
 


### PR DESCRIPTION
`mdast` has been renamed recently. This patch simply updates the dependencies to match the current names (and versions).

This repo could also be renamed to use the `remark-` prefix instead after this has been merged.
