### PR TITLE
rework sentence stop detection, support blacklist configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,33 +1,68 @@
 var visit = require('unist-util-visit');
 
 function sentenceNewline(ast, file, preferred, done) {
+  var blacklist = [];
+  if (typeof preferred === 'object' && !('length' in preferred)) {
+    blacklist = preferred.blacklist;
+  }
+
   visit(ast, 'text', function (node) {
-    var lastDotFoundIdx = -1;
+    var sentenceStops = ['!', '.', '?'];
 
-    while (lastDotFoundIdx < node.value.length) {
+    function getNextSentenceStop(value, startIndex) {
+      var result = {index: -1, sentenceStop: ''};
+      if (startIndex >= value.length) {
+        return result;
+      }
+      // search for all sentence stop types
+      // return the one with the lowest index
+      for (var i = 0; i < sentenceStops.length; ++i) {
+        var index = value.indexOf(sentenceStops[i], startIndex);
+        if (index === -1) {
+          continue;
+        }
+        if (result.index === -1 || index < result.index) {
+          result.index = index;
+          result.sentenceStop = sentenceStops[i];
+        }
+      }
+      return result;
+    }
 
-      var dotIdx = node.value.indexOf('.', lastDotFoundIdx + 1);
-
-      if (dotIdx === -1) {
+    var lastCandidate = {index: 0, sentenceStop: ''};
+    while (true) {
+      lastCandidate = getNextSentenceStop(
+        node.value, lastCandidate.index + lastCandidate.sentenceStop.length);
+      // abort if no more sentence stops are found
+      if (lastCandidate.index === -1) {
         break;
       }
-
-      if (dotIdx >= node.value.length - 1) {
-        lastDotFoundIdx = dotIdx;
+      // ignore if the sentence stop is the last character
+      if (lastCandidate.index >= node.value.length - 1) {
+        continue;
+      }
+      // ignore if the next character is not a space
+      if (node.value.charAt(lastCandidate.index + lastCandidate.sentenceStop.length) !== ' ') {
+        continue;
+      }
+      // ignore if the sentence stop (and its preceeding characters match a blacklisted string
+      var isBlacklisted = false;
+      for (var i = 0; i < blacklist.length; ++i) {
+        var needle = blacklist[i];
+        var startIndex = lastCandidate.index + lastCandidate.sentenceStop.length - needle.length;
+        if (node.value.substr(startIndex, needle.length) == needle) {
+          isBlacklisted = true;
+          break;
+        }
+      }
+      if (isBlacklisted) {
         continue;
       }
 
-      if (node.value.charAt(dotIdx + 1) === '\n') {
-        lastDotFoundIdx = dotIdx;
-        continue;
-      }
-
-      lastDotFoundIdx = dotIdx;
       file.warn(
         'Newline should follow end of sentence',
-        file.offsetToPosition(file.positionToOffset(node.position.start) + dotIdx)
+        file.offsetToPosition(file.positionToOffset(node.position.start) + lastCandidate.index)
       );
-
     }
 
   });


### PR DESCRIPTION
This patch reworks the sentence stop detection. It addresses many tickets at once (with one "regression" though):
- Check for different sentence stop characters (`.`, `?`, `!`) : #6
- Only consider dots which are followed by a space
  - Fixes #3: file, URL
  - Fixes #8: Decimal numbers
  - Fixes #11: Jekyll tags
  - This fails one of the tests since it breaks the current behavior that a dot without a space afterwards is detected "correctly". I think the _pros_ are more significant then the _con_. The behavior could also be exposed as an option?
- Support a blacklist option so anything can be explicitly excluded
  - Fixes #5: `etc.`
  - Fixes #7: `i.e.`, `.e.g.`
  - Fixes #9: `...`
  - Fixes #10: `Mr.`, `Mrs.`
  - Example config in `.remarkrc`:
    
    ```
    "external": ["mdast-lint-sentence-newline"],
    "sentence-newline": {
      "blacklist": ["e.g.", "E.g.", "etc.", "i.e.", "vs.", "..."]
    },
    ```
  - Currently the comparison is case sensitive. Maybe it should be case insensitive?
