### PR TITLE
do not force newline after sentence stops followed by quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,6 @@ function sentenceNewline(ast, file, preferred, done) {
 
   visit(ast, 'text', function (node) {
     var sentenceStops = [
-      '!"', '."', '?"', // Make sure these are placed above the next line.
-                        // Otherwise, since ! is included in !" for example,
-                        // !" will not be detected.
       '!', '.', '?'
     ];
 

--- a/test/end-and-quote/expected.js
+++ b/test/end-and-quote/expected.js
@@ -1,6 +1,4 @@
 var message = require('../createMessage');
 
 module.exports = [
-  message(1, 14),
-  message(1, 46)
 ];

--- a/test/end-and-quote/file.md
+++ b/test/end-and-quote/file.md
@@ -1,1 +1,1 @@
-"Hello, world." "This should be on a new line!" So should this.
+"Hello, world." "This should not be on a new line!" Some for this.


### PR DESCRIPTION
Addresses my comment https://github.com/chcokr/remark-lint-sentence-newline/issues/4#issuecomment-170366223

For the rational please see the discussion in the linked issue.
