### PR TITLE
Update remark

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 var visit = require('unist-util-visit');
+var vfileLocation = require('vfile-location');
 
 function sentenceNewline(ast, file, preferred, done) {
+  var location = vfileLocation(file);
   var blacklist = [];
   if (typeof preferred === 'object' && !('length' in preferred)) {
     blacklist = preferred.blacklist;
@@ -63,7 +65,7 @@ function sentenceNewline(ast, file, preferred, done) {
 
       file.warn(
         'Newline should follow end of sentence',
-        file.offsetToPosition(file.positionToOffset(node.position.start) + lastCandidate.index)
+        location.toPosition(location.toOffset(node.position.start) + lastCandidate.index)
       );
     }
 

--- a/package.json
+++ b/package.json
@@ -28,14 +28,15 @@
   },
   "homepage": "https://github.com/chcokr/remark-lint-sentence-newline#readme",
   "dependencies": {
-    "unist-util-visit": "^1.0.0"
+    "unist-util-visit": "^1.0.0",
+    "vfile-location": "^2.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.6",
     "istanbul": "^0.4.1",
     "mocha": "^2.3.4",
     "mocha-lcov-reporter": "^1.0.0",
-    "remark": "^3.1.0",
-    "remark-lint": "^2.0.0"
+    "remark": "^4.2.2",
+    "remark-lint": "^3.2.1"
   }
 }


### PR DESCRIPTION
- `vfile-location` was previously by accident leaked to other libraries, now it’s to be depended upon direclty;
- Updated dev-dependencies of remark, remark-lint;
- I found the tests were failing, but I don’t believe that has anything to do with the new code.
  Could you check what’s going on there?

Thanks @chcokr!
